### PR TITLE
Removing Email Address from Person records as unnecessary PII

### DIFF
--- a/src/Muddlr.Api/Person/PersonDto.cs
+++ b/src/Muddlr.Api/Person/PersonDto.cs
@@ -3,14 +3,13 @@ using Muddlr.WebFinger;
 
 namespace Muddlr.Api;
 
-internal record PersonDto(string Id, string Name, string Email, HashSet<string> Locators, HashSet<Uri>? Aliases, List<WebFingerLink>? Links, string FediverseServer, string FediverseHandle) : IPerson
+internal record PersonDto(string Id, string Name, HashSet<string> Locators, HashSet<Uri>? Aliases, List<WebFingerLink>? Links, string FediverseServer, string FediverseHandle) : IPerson
 {
     public static PersonDto FromPerson(Person person)
         => new
         (
             IdHasher.Instance.EncodeLong(person.Id),
             person.Name,
-            person.Email,
             person.Locators,
             person.Aliases,
             person.Links,

--- a/src/Muddlr.Api/Person/PersonExtensions.cs
+++ b/src/Muddlr.Api/Person/PersonExtensions.cs
@@ -12,7 +12,6 @@ internal static class PersonExtensions
             {
                 Id = person.Id,
                 Name = person.Name,
-                Email = person.Email,
                 Locators = person.Locators,
                 Aliases = person.Aliases,
                 FediverseHandle = person.FediverseHandle,

--- a/src/Muddlr.Api/Person/UpsertPersonDto.cs
+++ b/src/Muddlr.Api/Person/UpsertPersonDto.cs
@@ -3,7 +3,7 @@ using Muddlr.WebFinger;
 
 namespace Muddlr.Api;
 
-internal record UpsertPersonDto(string Name, string Email, string[] Locators, string FediverseHandle, string FediverseServer, string Id = "")
+internal record UpsertPersonDto(string Name, string[] Locators, string FediverseHandle, string FediverseServer, string Id = "")
 {
     public Person ToPerson()
     {
@@ -11,7 +11,6 @@ internal record UpsertPersonDto(string Name, string Email, string[] Locators, st
         {
             Id = string.IsNullOrEmpty(Id) ? default : IdHasher.Instance.DecodeSingleLong(Id),
             Name = Name,
-            Email = Email,
             Locators = new HashSet<string>(Locators.Select(loc =>
                 !loc.StartsWith("acct:", StringComparison.OrdinalIgnoreCase) ? $"acct:{loc}" : loc)),
             FediverseHandle = FediverseHandle,

--- a/src/Muddlr.Core/Persons/Person.cs
+++ b/src/Muddlr.Core/Persons/Person.cs
@@ -6,7 +6,6 @@ namespace Muddlr.Persons;
 public interface IPerson
 {
     string Name { get; }
-    string Email { get; }
     HashSet<string> Locators { get; }
     HashSet<Uri>? Aliases { get; }
     List<WebFingerLink>? Links { get; }
@@ -20,8 +19,6 @@ public class Person : IPerson
 
     [Required]
     public string Name { get; set; }
-    [Required]
-    public string Email { get; set; }
     public HashSet<string> Locators { get; set; } = new();
     public HashSet<Uri>? Aliases { get; set; }
     public List<WebFingerLink>? Links { get; set; } = new();

--- a/tests/Muddler.Api.Tests/InMemoryPersonRepository.cs
+++ b/tests/Muddler.Api.Tests/InMemoryPersonRepository.cs
@@ -21,7 +21,6 @@ internal class InMemoryPersonRepository : IPersonRepository
                     {
                         Id = kv.Value.Id,
                         Name = kv.Value.Name,
-                        Email = kv.Value.Email,
                         Locators = kv.Value.Locators,
                         Aliases = kv.Value.Aliases,
                         FediverseHandle = kv.Value.FediverseHandle,
@@ -44,7 +43,6 @@ internal class InMemoryPersonRepository : IPersonRepository
         {
             Id = nextId,
             Name = person.Name,
-            Email = person.Email,
             Locators = person.Locators,
             Aliases = person.Aliases,
             FediverseHandle = person.FediverseHandle,

--- a/tests/Muddler.Api.Tests/PersonApiTests.cs
+++ b/tests/Muddler.Api.Tests/PersonApiTests.cs
@@ -30,7 +30,6 @@ public class PersonApiTests: IDisposable
             new Person
             {
                 Name = "Matt Test",
-                Email = "mtest@test.com",
                 FediverseHandle = "tester",
                 FediverseServer = "test.social",
                 Locators = new HashSet<string> {"tester@thetest.com"},
@@ -91,7 +90,7 @@ public class PersonApiTests: IDisposable
     public async Task PersonRouteReturnsAllPeople()
     {
         var response = await _client.GetAsync("/api/person");
-        var people = await response.Content.ReadFromJsonAsync<Person[]>();
+        var people = await response.Content.ReadFromJsonAsync<PersonDto[]>();
 
         people.Should().NotBeNull();
         people.Should().NotBeEmpty();
@@ -101,9 +100,9 @@ public class PersonApiTests: IDisposable
     [Fact]
     public async Task GetPersonByIdReturnsCorrectPerson()
     {
-        const long id = 1;
-        var response = await _client.GetAsync($"/api/person/{id}");
-        var matt = await response.Content.ReadFromJsonAsync<Person>();
+        var hashId = IdHasher.Instance.EncodeLong(1);
+        var response = await _client.GetAsync($"/api/person/{hashId}");
+        var matt = await response.Content.ReadFromJsonAsync<PersonDto>();
         matt.Should().NotBeNull();
         matt!.Name.Should().Be("Matt Test");
     }
@@ -112,9 +111,10 @@ public class PersonApiTests: IDisposable
     public async Task AddPersonUpdatesRepositoryWithCorrectFediverseLinks()
     {
         var person = new UpsertPersonDto(
-            "John Test", 
-            "jt@thetest.com", 
-            new[] {"tester@thetest.com"}, "jt", "test.social");
+            "John Test",
+            new[] {"tester@thetest.com"}, 
+            "jt", 
+            "test.social");
         
         var expectedLinks = new List<WebFingerLink>
         {
@@ -136,7 +136,7 @@ public class PersonApiTests: IDisposable
         };
 
         var response = await _client.PostAsJsonAsync("/api/person/", person);
-        var result = await response.Content.ReadFromJsonAsync<Person>();
+        var result = await response.Content.ReadFromJsonAsync<PersonDto>();
 
         result.Should().NotBeNull();
         result!.Links.Should().BeEquivalentTo(expectedLinks);


### PR DESCRIPTION
Removing the `Email` field from `Person` because it's not currently in-use, making it unneeded PII. Originally was included as part of a plan for hooking auth into the `Person` entity, but instead we should either create a separate `User` entity with a link between `User` and `Person` or (potentially) push auth off onto a 3rd party service.