### PR TITLE
Replace nested constant strings with SmartEnums

### DIFF
--- a/src/Muddlr.Api/Muddlr.Api.csproj
+++ b/src/Muddlr.Api/Muddlr.Api.csproj
@@ -49,5 +49,9 @@
     <ItemGroup>
         <InternalsVisibleTo Include="Muddler.Api.Tests" />
     </ItemGroup>
+    
+    <ItemGroup>
+      <Folder Include="People" />
+    </ItemGroup>
 
 </Project>

--- a/src/Muddlr.Api/Person/UpsertPersonDto.cs
+++ b/src/Muddlr.Api/Person/UpsertPersonDto.cs
@@ -35,19 +35,19 @@ internal record UpsertPersonDto(string Name, string[] Locators, string Fediverse
         {
             new WebFingerLink
             {
-                Relationship = Relationships.WebFingerProfile,
-                Type = LinkTypes.Text.Html,
+                Relationship = Relationship.WebFingerProfile,
+                Type = LinkType.TextHtml,
                 Href = new Uri($"https://{FediverseServer}/@{FediverseHandle}")
             },
             new WebFingerLink
             {
-                Relationship = Relationships.Self,
-                Type = LinkTypes.Application.ActivityJson,
+                Relationship = Relationship.Self,
+                Type = LinkType.ApplicationActivityJson,
                 Href = new Uri($"https://{FediverseServer}/users/{FediverseHandle}")
             },
             new WebFingerLink
             {
-                Relationship = Relationships.OStatusSubscribe,
+                Relationship = Relationship.OStatusSubscribe,
                 Template = $"https://{FediverseServer}/authorize_interaction?uri={{uri}}"
             },
         };

--- a/src/Muddlr.Core/Muddlr.Core.csproj
+++ b/src/Muddlr.Core/Muddlr.Core.csproj
@@ -13,6 +13,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Ardalis.SmartEnum" Version="2.1.0" />
+        <PackageReference Include="Ardalis.SmartEnum.SystemTextJson" Version="2.1.0" />
+        <PackageReference Include="Ardalis.SmartEnum.Utf8Json" Version="2.1.0" />
         <PackageReference Include="Humanizer" Version="2.14.1" />
     </ItemGroup>
 

--- a/src/Muddlr.Core/WebFinger/LinkTypes.cs
+++ b/src/Muddlr.Core/WebFinger/LinkTypes.cs
@@ -1,19 +1,15 @@
-﻿namespace Muddlr.WebFinger;
+﻿using Ardalis.SmartEnum;
+using System.Text.Json.Serialization;
+using Ardalis.SmartEnum.SystemTextJson;
 
-public static class LinkTypes
+namespace Muddlr.WebFinger;
+
+public class LinkType: SmartEnum<LinkType, string?>
 {
-    public static class Text
-    {
-        private const string LiteralText = "text";
-        
-        public const string Html = $"{LiteralText}/html";
-        public const string Json = $"{LiteralText}/json";
-    }
-
-    public static class Application
-    {
-        private const string LiteralApplication = "application";
-
-        public const string ActivityJson = $"{LiteralApplication}/activity+json";
-    }
+    public static LinkType None = new(name: nameof(None), value: null);
+    public static LinkType TextHtml = new(name: nameof(TextHtml), value: "text/html");
+    public static LinkType ApplicationActivityJson =
+        new(name: nameof(ApplicationActivityJson), value: "application/activity+json");
+    
+    private LinkType(string name, string? value) : base(name, value ?? "") { }
 }

--- a/src/Muddlr.Core/WebFinger/Relationships.cs
+++ b/src/Muddlr.Core/WebFinger/Relationships.cs
@@ -1,8 +1,19 @@
-﻿namespace Muddlr.WebFinger;
+﻿using System.Text.Json.Serialization;
+using Ardalis.SmartEnum;
+using Ardalis.SmartEnum.SystemTextJson;
 
-public static class Relationships
+namespace Muddlr.WebFinger;
+
+public class Relationship : SmartEnum<Relationship, string>
 {
-    public const string Self = "self";
-    public const string WebFingerProfile = "http://webfinger.net/rel/profile-page";
-    public const string OStatusSubscribe = "http://ostatus.org/schema/1.0/subscribe";
+    public static readonly Relationship None = new(nameof(None), "");
+    public static readonly Relationship Self = new(name: nameof(Self), value: "self");
+
+    public static readonly Relationship WebFingerProfile =
+        new(name: nameof(WebFingerProfile), value: "http://webfinger.net/rel/profile-page");
+
+    public static readonly Relationship OStatusSubscribe =
+        new(name: nameof(OStatusSubscribe), value: "http://ostatus.org/schema/1.0/subscribe");
+
+    private Relationship(string name, string value) : base(name, value) { }
 }

--- a/src/Muddlr.Core/WebFinger/WebFingerLink.cs
+++ b/src/Muddlr.Core/WebFinger/WebFingerLink.cs
@@ -1,12 +1,16 @@
-using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using Ardalis.SmartEnum.SystemTextJson;
 
 namespace Muddlr.WebFinger;
 
 public class WebFingerLink
 {
-    [Required]
-    public string Relationship { get; set; }
-    public string? Type { get; set; }
+    [JsonConverter(typeof(SmartEnumValueConverter<Relationship, string>))]
+    public Relationship Relationship { get; set; }
+    
+    [JsonConverter(typeof(SmartEnumValueConverter<LinkType, string?>))]
+    public LinkType? Type { get; set; }
+    
     public Uri? Href { get; set; }
     public Dictionary<string, string>? Titles { get; set; }
     public string? Template { get; set; }


### PR DESCRIPTION
- Replaced nested constant strings with SmartEnums. 
- Wrestled with bson serialization until it finally admitted that I just needed to set a constructor in the global mapper and I should stop being an idiot. 
- Tests now utilize LiteDb via temp-file