### PR TITLE
Adding default redirect

### DIFF
--- a/src/Muddlr.Api/Muddlr.Api.csproj
+++ b/src/Muddlr.Api/Muddlr.Api.csproj
@@ -49,5 +49,9 @@
     <ItemGroup>
         <InternalsVisibleTo Include="Muddler.Api.Tests" />
     </ItemGroup>
+    
+    <ItemGroup>
+      <Folder Include="wwwroot" />
+    </ItemGroup>
 
 </Project>

--- a/src/Muddlr.Api/MuddlrApiConfig.cs
+++ b/src/Muddlr.Api/MuddlrApiConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace Muddlr.Api;
+
+public class MuddlrApiConfig
+{
+    public bool ForceHttps { get; set; }
+    public string? ForDomain { get; set; }
+}

--- a/src/Muddlr.Api/Pages/Index.cshtml
+++ b/src/Muddlr.Api/Pages/Index.cshtml
@@ -1,0 +1,24 @@
+﻿@page
+@model Muddlr.Api.Pages.Index
+
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <title>Muddlr</title>
+</head>
+<body>
+<h1>
+    A Muddlr Server
+</h1>
+<div>
+    Core Version: @Model.CoreVersion <br />
+    Api Version: @Model.ApiVersion <br />
+    Status: @Model.ServerStatus
+</div>
+</body>
+</html>

--- a/src/Muddlr.Api/Pages/Index.cshtml.cs
+++ b/src/Muddlr.Api/Pages/Index.cshtml.cs
@@ -1,0 +1,28 @@
+﻿using System.Reflection;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Muddlr.Api.HealthStatus;
+using Muddlr.WebFinger;
+
+namespace Muddlr.Api.Pages;
+
+public class Index : PageModel
+{
+    private MuddlrStatus _status;
+    public string ApiVersion => _status.ApiVersion;
+    public string CoreVersion => _status.CoreVersion;
+    public string ServerStatus => _status.Status.ToString();
+    public void OnGet()
+    {
+        var apiAssembly = Assembly.GetExecutingAssembly().GetName();
+        var apiVersion = apiAssembly.Version is not null
+            ? apiAssembly.Version.ToString()
+            : "UNK";
+
+        var coreAssembly = typeof(WebFingerRecord).Assembly.GetName();
+        var coreVersion = coreAssembly.Version is not null
+            ? coreAssembly.Version.ToString()
+            : "UNK";
+
+        _status = new MuddlrStatus {ApiVersion = apiVersion, CoreVersion = coreVersion, Status = HealthStatus.HealthStatus.Ok};
+    }
+}

--- a/src/Muddlr.Api/Pages/NotFound.cshtml
+++ b/src/Muddlr.Api/Pages/NotFound.cshtml
@@ -1,0 +1,20 @@
+﻿@page
+@model Muddlr.Api.Pages.NotFound
+
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <title>User Not Found</title>
+</head>
+<body>
+<h1>Not Found</h1>
+<div>
+    The user profile you requested could not be found
+</div>
+</body>
+</html>

--- a/src/Muddlr.Api/Pages/NotFound.cshtml.cs
+++ b/src/Muddlr.Api/Pages/NotFound.cshtml.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Muddlr.Api.Pages;
+
+public class NotFound : PageModel
+{
+    public void OnGet()
+    {
+        
+    }
+}

--- a/src/Muddlr.Api/WebFinger/WebFingerApi.cs
+++ b/src/Muddlr.Api/WebFinger/WebFingerApi.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http.HttpResults;
 using Muddlr.WebFinger;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -8,10 +9,11 @@ internal static class WebFingerApi
 {
     public static RouteGroupBuilder MapWebFingerApi(this IEndpointRouteBuilder routes)
     {
-        var group = routes.MapGroup("/.well-known/webfinger/");
+        // var group = routes.MapGroup("/.well-known/webfinger/");
+        var group = routes.MapGroup("/");
         group.WithTags("WebFinger");
 
-        group.MapGet("/", async ([FromQuery, BindRequired] string resource, [FromQuery] string[] rel, WebFingerRequestHandler handler) =>
+        group.MapGet("/.well-known/webfinger/", async ([FromQuery, BindRequired] string resource, [FromQuery] string[] rel, WebFingerRequestHandler handler) =>
         {
             var request = new WebFingerRequest {Resource = resource, Relationships = rel};
             var (status, response) = await handler.ProcessWebFingerRequest(request);
@@ -20,6 +22,26 @@ internal static class WebFingerApi
                 ? Results.Ok(response)
                 : Results.NotFound("Cannot find the requested resource");
         }).RequireCors("Everybody");
+        group.MapGet("/@{locator}", async (string locator, HttpContext context, MuddlrApiConfig config, IWebFingerService fingerService) =>
+        {
+            var hostString = string.IsNullOrEmpty(config.ForDomain)
+                ? context.Request.Host.Host
+                : config.ForDomain;
+            
+            var fullLocator = $"acct:{locator}@{hostString}";
+            var record = await fingerService.GetWebFingerRecord(fullLocator, Relationship.WebFingerProfile);
+
+            if (record is not {Links: {Count: > 0}})
+            {
+                return Results.NotFound();
+            }
+            
+            var profile = record.Links.Single().Href?.ToString();
+
+            return !string.IsNullOrEmpty(profile) 
+                ? Results.Redirect(profile, false, false) 
+                : Results.NotFound();
+        });
 
         return group;
     }

--- a/src/Muddlr.Api/appsettings.Development.json
+++ b/src/Muddlr.Api/appsettings.Development.json
@@ -31,7 +31,7 @@
     }
   },
   "muddlr": {
-    "hashIdSalt": "as;lkja;lkmf;lekam;lkfema;lkas839[94a;lsk",
-    "forceHttps": false
+    "forceHttps": false,
+    "forDomain": "cocktailians.info"
   }
 }

--- a/src/Muddlr.Api/appsettings.json
+++ b/src/Muddlr.Api/appsettings.json
@@ -32,7 +32,6 @@
   },
   "AllowedHosts": "*",
   "muddlr": {
-    "hashIdSalt": "as;lkja;lkmf;lekam;lkfema;lkas839[94a;lsk",
     "forceHttps": false
   }
 }

--- a/src/Muddlr.Core/WebFinger/Relationships.cs
+++ b/src/Muddlr.Core/WebFinger/Relationships.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using Ardalis.SmartEnum;
-using Ardalis.SmartEnum.SystemTextJson;
+﻿using Ardalis.SmartEnum;
 
 namespace Muddlr.WebFinger;
 


### PR DESCRIPTION
Adds redirect for users (e.g. https://example.com/@someuser can now automatically redirect to the user's profile page on their real server). Addresses #8 by adding a `forDomain` setting to the appsettings. This doesn't yet allow for shorter locators.

Also adds a home landing page for the server with the Muddlr version and status (instead of redirecting to the health endpoint) and a "user not found" page when no user can be found for a given profile.